### PR TITLE
Correct mwSize mismatch for modern mex

### DIFF
--- a/+prtExternal/+combinator/cumsumall.cpp
+++ b/+prtExternal/+combinator/cumsumall.cpp
@@ -115,7 +115,7 @@ void cs_int32(const mxArray *inp,const mxArray *oup,int row, int col)
 void mexFunction( int nlhs,mxArray *plhs[],int nrhs,const mxArray *prhs[])
 {
     mxClassID   category;
-    const int *dm;  // Rows and Columns.
+    const unsigned long *dm;  // Rows and Columns.
     int nd; // Number of dimensions.
     
     category = mxGetClassID(prhs[0]);


### PR DESCRIPTION
prtSetupMex was stalling out on a 2025a install on arm64.  In the external dependencies cumsumall.cpp  needs a small change for 64bit datatypes with mwSize.